### PR TITLE
do not render a date when date fields empty

### DIFF
--- a/app/components/app/record/RecordView.js
+++ b/app/components/app/record/RecordView.js
@@ -124,39 +124,52 @@ define([
                                         ? record.getColumnValue(dateCol.specificityColumn)
                                         : 't';
                                       if (dateCol.minColumn && dateCol.maxColumn) {
-                                        minValue = new Date(
-                                          record.parseDate(
-                                            record.getColumnValue(dateCol.minColumn)
-                                          )
-                                        );
-                                        maxValue = new Date(
-                                          record.parseDate(
-                                            record.getColumnValue(dateCol.maxColumn)
-                                          )
-                                        );
-                                        if (specValue === 'y') {
-                                          minValue = minValue.getFullYear();
-                                          maxValue = maxValue.getFullYear();
-                                        } else if (specValue === 'm' || specValue === 'd' ) {
-                                          minValue = minValue.toLocaleDateString('en-NZ')
-                                          maxValue = maxValue.toLocaleDateString('en-NZ')
-                                        } else { // 't'
-                                          minValue = minValue.toLocaleString('en-NZ')
-                                          maxValue = maxValue.toLocaleString('en-NZ')
-                                        }
-                                        var res = memo.concat(
-                                          that.getAuxRangeColumnHTML(
-                                            dateCol.minColumn,
-                                            minValue,
-                                            maxValue,
-                                            dateCol.title
-                                          )
-                                        );
-                                        if (dateCol.certaintyColumn) {
-                                          res = res.concat(
-                                            that.getCertaintyColumnHtml(
-                                              dateCol.certaintyColumn,
-                                              '&mdash; ' + labels.record.certainty_title
+                                        var minVal = record.getColumnValue(dateCol.minColumn);
+                                        var maxVal = record.getColumnValue(dateCol.maxColumn);
+                                        if ((minVal && minVal.trim() !== '') || (maxVal && maxVal.trim() !== '')) {
+                                          minValue = new Date(
+                                            record.parseDate(
+                                              record.getColumnValue(dateCol.minColumn)
+                                            )
+                                          );
+                                          maxValue = new Date(
+                                            record.parseDate(
+                                              record.getColumnValue(dateCol.maxColumn)
+                                            )
+                                          );
+                                          if (specValue === 'y') {
+                                            minValue = minValue.getFullYear();
+                                            maxValue = maxValue.getFullYear();
+                                          } else if (specValue === 'm' || specValue === 'd' ) {
+                                            minValue = minValue.toLocaleDateString('en-NZ')
+                                            maxValue = maxValue.toLocaleDateString('en-NZ')
+                                          } else { // 't'
+                                            minValue = minValue.toLocaleString('en-NZ')
+                                            maxValue = maxValue.toLocaleString('en-NZ')
+                                          }
+                                          var res = memo.concat(
+                                            that.getAuxRangeColumnHTML(
+                                              dateCol.minColumn,
+                                              minValue,
+                                              maxValue,
+                                              dateCol.title
+                                            )
+                                          );
+                                          if (dateCol.certaintyColumn) {
+                                            res = res.concat(
+                                              that.getCertaintyColumnHtml(
+                                                dateCol.certaintyColumn,
+                                                '&mdash; ' + labels.record.certainty_title
+                                              )
+                                            );
+                                          }
+                                        } else {
+                                          res = memo.concat(
+                                            that.getAuxRangeColumnHTML(
+                                              dateCol.minColumn,
+                                              null,
+                                              null,
+                                              dateCol.title
                                             )
                                           );
                                         }
@@ -290,12 +303,21 @@ define([
     },
     getAuxRangeColumnHTML:function(id, minValue, maxValue, title){
       var labels = this.model.getLabels();
-      return _.template(templateColumnTextSecondary)({
-        t:labels,
-        title: title || labels.record.comment,
-        value:minValue === maxValue ? minValue : minValue + ' - ' + maxValue,
-        id:id
-      })
+      if (minValue) {
+        return _.template(templateColumnTextSecondary)({
+          t:labels,
+          title: title || labels.record.comment,
+          value: (maxValue && minValue === maxValue) ? minValue : minValue + ' - ' + maxValue,
+          id:id
+        })
+      } else {
+        return _.template(templateColumnTextSecondary)({
+          t:labels,
+          title: title || labels.record.comment,
+          value: '&mdash; ',
+          id:id
+        })
+      }
     },
     getCertaintyColumnHtml:function(certCol, title){
       var record = this.model.get("record")


### PR DESCRIPTION
This is to fix an issue with rendering unspecified "auxiliary dates", which are dates that belong to other columns

Without making sure that a date is present, the app currently outputs 1/01/1970, 12:00:00 pm which is the result of `new Date(null)`, as can be seen here for example for the record 810 (https://tsunami.gns.cri.nz/#!/db/r810)

![unnamed](https://github.com/GNS-Science/nz-tsunami-db/assets/5811956/d550fef3-993e-4eec-a991-a8bab854631a)


The fix will check for the presence of both min and max dates and if not present outputs an mdash (&mdash;) as used elsewhere for missing data (and also removes the obsolete (and unspecified) certainty value. The result can be seen here:

![unnamed](https://github.com/GNS-Science/nz-tsunami-db/assets/5811956/c5f0110c-731d-4534-89e3-f0ef50a6a899)
