### PR TITLE
fixed references sort order and delete stray empty row 

### DIFF
--- a/app/data/gns_references.csv
+++ b/app/data/gns_references.csv
@@ -4,9 +4,9 @@
 3,3,Beattie 1915b,"Beattie, H. 1915b. Traditions and Legends collected from the natives of Murihiku. (Southland, New Zealand). Part II. Journal of the Polynesian Society 24: 130-139."
 4,4,Downes 1914,"Downes, T.W. 1914. History of Ngati-Kahu-Ngunu (Chapter I, part 2). Journal of the Polynesian Society 23: 11-125."
 5,5a,King et al. 2007a,"King, D. N. T., Goff, J., Skipper, A. 2007. Māori Environmental Knowledge and natural hazards in Aotearoa-New Zealand. Journal of the Royal Society of New Zealand 37 (2): 59-73. (and references therein)"
-5,5,King et al. 2007b,"King, D.N.T., Goff, J., Skipper, A. 2007. Māori Environmental Knowledge and natural hazards in Aotearoa-New Zealand. Journal of the Royal Society of New Zealand 37 (2): 59-73."
-6,6,Stack 1877,"Stack, J.W. 1877. Sketch of the traditional history of the South Island Maoris. Transactions of the New Zealand Institute, 10: 57-92."
-7,7,Smith 1897,"Smith S P 1897. The peopling of the north: notes on the ancient Maori history of the northern peninsula and sketches of the history of Ngati-Whatua tribe of the Kaipara, New Zealand. Supplement to Journal of the Polynesian Society 6: 76–77."
+6,5,King et al. 2007b,"King, D.N.T., Goff, J., Skipper, A. 2007. Māori Environmental Knowledge and natural hazards in Aotearoa-New Zealand. Journal of the Royal Society of New Zealand 37 (2): 59-73."
+7,6,Stack 1877,"Stack, J.W. 1877. Sketch of the traditional history of the South Island Maoris. Transactions of the New Zealand Institute, 10: 57-92."
+8,7,Smith 1897,"Smith S P 1897. The peopling of the north: notes on the ancient Maori history of the northern peninsula and sketches of the history of Ngati-Whatua tribe of the Kaipara, New Zealand. Supplement to Journal of the Polynesian Society 6: 76–77."
 9,9,Mitchell & Mitchell 2004,"Mitchell, J., Mitchell, H. 2004 ""Te Tau Ihu o Te Waka A history of Maori of Nelson and Marlborough"". Volume 1 Te tangata me t Whenua: the People and the Land. Wellington, New Zealand: Huia Publishers."
 10,10,Smith 1910,Smith S.P. 1910. History and traditions of the Maoris of the West Coast North Island of New Zealand prior to 1840. Memoirs of the Polynesian Society I: 175–185.
 11,11,Downes et al. 2005,"Downes, G., Cochran, U., Wallace, L., Reyners, M., Berryman, K. (GNS), Walters, R., Callaghan, F., Barnes, P., Bell, R. (NIWA) 2005. EQC Project 03/490 - Understanding local source tsunami: 1820s Southland tsunami. Prepared for Earthquake Commission (EQC) Research Foundation. Institute of Geological & Nuclear Sciences client report 2005/153; National Institute for Water and Atmospheric Research Consultancy report HAM2005-135."
@@ -94,4 +94,3 @@
 95,95,ITIC 2009,"ITIC event summary provided by Rob Bell, 3/10/2009"
 96,96,3News,3 News NZ 
 97,97,Lay et al 2013,"Lay, T., Ye, L., Kanamori, H., Yamazaki, Y., Cheung, K.F. and Ammon, C.J., 2013. The February 6, 2013 Mw 8.0 Santa Cruz Islands earthquake and tsunami. Tectonophysics, 608, pp. 1109-1121."
-,,,


### PR DESCRIPTION
This is a minor change to the references table that only affects the "sort" column that is NOT USED by the application. It also removes a stray empty row that should have never been there in the first place. None of these changes should affect the way the data is presented in the app